### PR TITLE
updated version to 2017.3

### DIFF
--- a/PyCharm-community/PyCharm-community.nuspec
+++ b/PyCharm-community/PyCharm-community.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>PyCharm-community</id>
-    <version>2017.2.4.1</version>
+    <version>2017.2.4</version>
     <title>PyCharm (Install)</title>
     <authors>Jetbrains</authors>
     <owners>BigSkylie</owners>

--- a/PyCharm-community/PyCharm-community.nuspec
+++ b/PyCharm-community/PyCharm-community.nuspec
@@ -14,7 +14,7 @@
     <description>Open source edition of the intelligent Python IDE with unique code assistance and analysis, for productive Python development on all levels.</description>
     <summary>PyCharm</summary>
 	    <dependencies>
-      <dependency id='jdk8' />
+      <dependency id='jre8' />
     </dependencies>
     <releaseNotes />
     <copyright />

--- a/PyCharm-community/PyCharm-community.nuspec
+++ b/PyCharm-community/PyCharm-community.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>PyCharm-community</id>
-    <version>2017.2.4</version>
+    <version>2017.3</version>
     <title>PyCharm (Install)</title>
     <authors>Jetbrains</authors>
     <owners>BigSkylie</owners>

--- a/PyCharm-community/tools/chocolateyInstall.ps1
+++ b/PyCharm-community/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageArgs = @{
   packageName   = 'PyCharm-community'
   fileType      = 'EXE'
-  url           = "https://download.jetbrains.com/python/pycharm-community-2017.2.4.exe"
+  url           = "https://download.jetbrains.com/python/pycharm-community-$env:ChocolateyPackageVersion.exe"
   silentArgs    = '/S'
   validExitCodes= @(0)
   checksum      = 'd3312df221bf88420981f3405d85e23622807d487367f76e1b1e893e95837c70'

--- a/PyCharm-community/tools/chocolateyInstall.ps1
+++ b/PyCharm-community/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@
   url           = "https://download.jetbrains.com/python/pycharm-community-$env:ChocolateyPackageVersion.exe"
   silentArgs    = '/S'
   validExitCodes= @(0)
-  checksum      = 'd3312df221bf88420981f3405d85e23622807d487367f76e1b1e893e95837c70'
+  checksum      = 'cf3eb25ccd4fc25b2f91dd7bdd031d5d195e98c2735898ea608f01baa0bc9b5d'
   checksumType  = 'sha256'
 }
 


### PR DESCRIPTION
sorry, I forgot to pull your changes before I updated the version.
Furthermore I suggest just requiring jre8.  PyCharm doesn't need jdk8, I think.  Is there any reason, why you've required it?  NuSpec seems not to have more complicated dependencies like either jre8 or jdk8.